### PR TITLE
bump CI pinned NetBox from v4.4.2 to v4.5.7

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,7 +57,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       netbox:
-        image: netboxcommunity/netbox:v4.4.2
+        image: netboxcommunity/netbox:v4.5.7
         env:
           ALLOWED_HOSTS: "*"
           DB_HOST: postgres

--- a/docs/compat.md
+++ b/docs/compat.md
@@ -6,7 +6,7 @@ series is inferred from the absence of breaking api changes in that range.
 
 | netbox.rs | netbox  | notes                                |
 |-----------|---------|--------------------------------------|
-| 0.3.x     | 4.4.x   | CI pinned to v4.4.2                  |
+| 0.3.x     | 4.4.x – 4.5.x | CI pinned to v4.5.7                  |
 
 older client releases have not been retroactively tested.
 


### PR DESCRIPTION
Bump the integration CI NetBox image tag from v4.4.2 to v4.5.7 and update compat.md to reflect 4.4.x–4.5.x coverage.

This is a minor-version upstream release. The oasdiff breaking-change check and smoke tests in CI will confirm compatibility.

Closes #11

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._