### PR TITLE
release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ this release captures the current state of the project. no prior published state
 
 ## [unreleased]
 
+## [0.5.0] - 2026-05-23
+
 ### openapi
 - regenerate bindings from NetBox v4.6.0 schema; adds `CableBundle`, `RackGroup`, `VirtualMachineType`, and `JobNotifications` models; removes `CreateAvailableVlanRequestRole`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 authors = ["cyber witchery labs"]
 edition = "2024"
 rust-version = "1.91"
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # netbox bindings
-netbox-openapi = { version = "0.4.0", path = "crates/netbox-openapi" }
+netbox-openapi = { version = "0.5.0", path = "crates/netbox-openapi" }
 
 # Error handling
 thiserror = "1.0"

--- a/crates/netbox-cli/Cargo.toml
+++ b/crates/netbox-cli/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-netbox = { version = "0.4.0", path = "../netbox" }
+netbox = { version = "0.5.0", path = "../netbox" }
 clap = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Closes #22.

## Changes

- bump workspace version 0.4.0 → 0.5.0
- bump `netbox-openapi` dep 0.4.0 → 0.5.0 (workspace.dependencies)
- bump `netbox` dep 0.4.0 → 0.5.0 in `netbox-cli`
- CHANGELOG.md: move v4.6.0 unreleased entries under `[0.5.0] - 2026-05-23`

## Release contents

See [#22](https://github.com/cyberwitchery/netbox.rs/issues/22) for the full breakdown. v0.5.0 covers the NetBox v4.6.0 bump (CableBundle/RackGroup/VirtualMachineType resources, removed CreateAvailableVlanRequestRole) plus client + CLI surface for the new endpoints.

## Tag

After merge, push tag `v0.5.0` to trigger the publish workflow.