### PR TITLE
release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ this release captures the current state of the project. no prior published state
 
 ## [unreleased]
 
+## [0.5.1] - 2026-05-23
+
+### build
+- override `[profile.dev.package.netbox-openapi] debug = 0` so docs.rs no longer OOMs compiling the generated bindings with `-C debuginfo=2`; affects only dev-profile builds of `netbox-openapi` as a dependency
+
 ## [0.5.0] - 2026-05-23
 
 ### openapi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = ["cyber witchery labs"]
 edition = "2024"
 rust-version = "1.91"
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # netbox bindings
-netbox-openapi = { version = "0.5.0", path = "crates/netbox-openapi" }
+netbox-openapi = { version = "0.5.1", path = "crates/netbox-openapi" }
 
 # Error handling
 thiserror = "1.0"
@@ -39,6 +39,12 @@ clap = { version = "4.5", features = ["derive", "env"] }
 
 # URL handling
 url = "2.5"
+
+# docs.rs OOMs compiling netbox-openapi as a dep of netbox with -C debuginfo=2.
+# The generated bindings are 326k lines; full debuginfo blows past the builder's
+# 6 GB memory limit. Drop debuginfo for this dep only.
+[profile.dev.package.netbox-openapi]
+debug = 0
 
 [profile.release]
 opt-level = 3

--- a/crates/netbox-cli/Cargo.toml
+++ b/crates/netbox-cli/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-netbox = { version = "0.5.0", path = "../netbox" }
+netbox = { version = "0.5.1", path = "../netbox" }
 clap = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Fixes docs.rs build failure for the `netbox` crate.

## Problem

docs.rs has been failing to build docs for `netbox` since v0.4.0 with an OOM during `netbox-openapi` compilation:

```
container ran out of memory
docker -m 6442450944  ← 6 GB
...
error: could not compile `netbox-openapi` (lib)
  ... -C debuginfo=2 ...  (signal: 9, SIGKILL: kill)
```

The generated bindings are ~326k lines; rustc with full debuginfo blows past the docs.rs builder's memory limit. Only the `netbox` crate is affected — `netbox-openapi` builds fine standalone because docs.rs doesn't apply debuginfo=2 to the crate being documented, only to its deps.

## Fix

Add a workspace profile override:

```toml
[profile.dev.package.netbox-openapi]
debug = 0
```

Scopes the change to `netbox-openapi` in dev profile only. Workspace developers lose debug-stepping into the generated bindings (which is rarely useful for generated code anyway); everything else keeps its debuginfo.

## Affected versions

| Version | netbox docs | netbox-openapi docs |
|---|---|---|
| 0.3.3 | ✓ | ✓ |
| 0.4.0 | ✗ OOM | ✓ |
| 0.5.0 | ✗ OOM | ✓ |
| 0.5.1 | (should pass) | ✓ |

## Side effect

The poisoned CI caches on main were deleted via gh api just before this PR was opened, so the CI run for this merge will be cold and save a fresh complete cache for subsequent runs.