### PR TITLE
ci: try kache instead of Swatinem/rust-cache (experiment)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-all-crates: true
+      - uses: kunobi-ninja/kache-action@v1
       - run: cargo clippy -p netbox -p netbox-cli --all-targets -- -D warnings
 
   test:
@@ -46,9 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-all-crates: true
+      - uses: kunobi-ninja/kache-action@v1
       - run: cargo test -p netbox -p netbox-cli
 
   doc:
@@ -59,9 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-all-crates: true
+      - uses: kunobi-ninja/kache-action@v1
       - run: cargo doc --workspace --no-deps
 
   deny:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           components: clippy
       - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-clippy
       - run: cargo clippy -p netbox -p netbox-cli --all-targets -- -D warnings
 
   test:
@@ -45,6 +47,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-test
       - run: cargo test -p netbox -p netbox-cli
 
   doc:
@@ -56,6 +60,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-doc
       - run: cargo doc --workspace --no-deps
 
   deny:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Cache cargo
         uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-integration
 
       - name: Wait for NetBox readiness
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,9 +83,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-all-crates: true
+        uses: kunobi-ninja/kache-action@v1
 
       - name: Wait for NetBox readiness
         run: |


### PR DESCRIPTION
**Experiment, not commitment.** Measure kache as a replacement for Swatinem/rust-cache after the previous cache fixes saved <1 min on the 13-min integration job.

## Change

Replace `Swatinem/rust-cache@v2` with `kunobi-ninja/kache-action@v1` in all 4 cache steps (ci.yml: clippy/test/doc, integration.yml: smoke-and-golden).

## Why

Swatinem's design has known limitations that the previous PRs hit head-on:
- Workspace-crate artifacts are purged before save (netbox-openapi rebuilds every run — ~2 min)
- Target-dir snapshot + mtime-sensitive cargo fingerprints means restored artifacts often get invalidated (ring's build.rs cascade — ~3 min in the TLS chain)
- Cache key is per-job, so jobs don't share

Kache is a `RUSTC_WRAPPER` that caches each rustc invocation by content hash of inputs (source bytes, flags, deps), bypassing Cargo's fingerprint system entirely. Workspace crates are cached like any other crate. Build script outputs are cached. Mtime resets after `actions/checkout` don't matter.

## What to look for

Two CI runs minimum:
1. **First run on this branch**: cold (no kache cache exists yet); should be roughly same as current cold time
2. **Subsequent push or rebase**: warm; the *real* measurement

The kache-action posts a sticky PR comment with hit/miss stats. Compare against the steady-state numbers from the merge of #27:
- ci test job: 2m 59s with 3 Compiling lines
- integration smoke-and-golden: ~13 min with 9 Compiling lines + ring cascade

If kache doesn't move the needle either, the conclusion is structural: `netbox-openapi` is the dominant cost and the only fix is splitting it.

## Rollback

Single commit on its own branch. Revert is trivial.