### PR TITLE
release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ this release captures the current state of the project. no prior published state
 
 ## [unreleased]
 
+## [0.5.2] - 2026-05-31
+
+### build
+- duplicate the `[profile.dev.package.netbox-openapi] debug = 0` override into `crates/netbox/Cargo.toml` so it survives `cargo publish` and reaches docs.rs; the workspace-root setting added in 0.5.1 was stripped when packaging the per-crate manifest, leaving docs.rs unfixed
+
 ## [0.5.1] - 2026-05-23
 
 ### build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "netbox"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "httpmock",
  "netbox-openapi",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "netbox-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "clap",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "netbox-openapi"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 authors = ["cyber witchery labs"]
 edition = "2024"
 rust-version = "1.91"
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # netbox bindings
-netbox-openapi = { version = "0.5.1", path = "crates/netbox-openapi" }
+netbox-openapi = { version = "0.5.2", path = "crates/netbox-openapi" }
 
 # Error handling
 thiserror = "1.0"

--- a/crates/netbox-cli/Cargo.toml
+++ b/crates/netbox-cli/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-netbox = { version = "0.5.1", path = "../netbox" }
+netbox = { version = "0.5.2", path = "../netbox" }
 clap = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/netbox/Cargo.toml
+++ b/crates/netbox/Cargo.toml
@@ -35,3 +35,6 @@ tracing = ["dep:tracing"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[profile.dev.package.netbox-openapi]
+debug = 0


### PR DESCRIPTION
Re-attempt the docs.rs fix from v0.5.1, which didn't actually reach docs.rs.

## What went wrong with v0.5.1

The v0.5.1 fix added `[profile.dev.package.netbox-openapi] debug = 0` to the workspace root `Cargo.toml`. Workspace-root profile settings only take effect during workspace builds — `cargo publish` packages the per-crate manifest, which had no profile entry. The published `netbox v0.5.1` Cargo.toml on crates.io has no `[profile.*]` at all, so docs.rs built it the same way as v0.5.0 and OOM'd again on `netbox-openapi` (build #3358385, signal 9 SIGKILL).

Verified by extracting the published `.crate` archive and grepping for `profile` — no hits.

## What v0.5.2 does

Adds the profile override to `crates/netbox/Cargo.toml` (the published manifest). Verified with `cargo package -p netbox` that the resulting `Cargo.toml` inside the `.crate` archive contains the override.

Local builds emit a benign cargo warning (`profiles for the non root package will be ignored`) — that's expected; the workspace-root override is what applies locally.