### PR TITLE
release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ this release captures the current state of the project. no prior published state
 
 ## [unreleased]
 
+## [0.5.3] - 2026-05-31
+
+### build
+- gate per-tag API modules (`dcim_api`, `ipam_api`, `vpn_api`, etc.) behind `#[cfg(not(docsrs))]` so docs.rs skips compiling them — they account for ~78% of `netbox-openapi`'s ~420k lines, and rustc OOMs on them at the docs.rs container limit (peak 6.58 GiB needed, 6 GiB available). The high-level `netbox` client never calls these per-tag functions (only re-exports them), so users on crates.io see no behaviour change; only `docs.rs/netbox-openapi/` loses the per-tag pages.
+- the previous `[profile.dev.package.netbox-openapi] debug = 0` override (added in 0.5.1, propagated correctly in 0.5.2) was insufficient on its own — debuginfo wasn't the dominant cost; type-checking the generated derives was.
+- post-processing in `scripts/generate.sh` injects the gates automatically on subsequent regenerations.
+- added a `build.rs` to `netbox-openapi` that translates `DOCS_RS=1` (set by docs.rs) into `cfg(docsrs)` (the standard idiom for crate-local docs.rs cfg).
+
 ## [0.5.2] - 2026-05-31
 
 ### build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "netbox"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "httpmock",
  "netbox-openapi",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "netbox-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "clap",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "netbox-openapi"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 authors = ["cyber witchery labs"]
 edition = "2024"
 rust-version = "1.91"
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # netbox bindings
-netbox-openapi = { version = "0.5.2", path = "crates/netbox-openapi" }
+netbox-openapi = { version = "0.5.3", path = "crates/netbox-openapi" }
 
 # Error handling
 thiserror = "1.0"

--- a/crates/netbox-cli/Cargo.toml
+++ b/crates/netbox-cli/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-netbox = { version = "0.5.2", path = "../netbox" }
+netbox = { version = "0.5.3", path = "../netbox" }
 clap = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/netbox-openapi/build.rs
+++ b/crates/netbox-openapi/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(docsrs)");
+    if std::env::var("DOCS_RS").is_ok() {
+        println!("cargo:rustc-cfg=docsrs");
+    }
+}

--- a/crates/netbox-openapi/src/apis/mod.rs
+++ b/crates/netbox-openapi/src/apis/mod.rs
@@ -92,18 +92,31 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+#[cfg(not(docsrs))]
 pub mod authentication_check_api;
+#[cfg(not(docsrs))]
 pub mod circuits_api;
+#[cfg(not(docsrs))]
 pub mod core_api;
+#[cfg(not(docsrs))]
 pub mod dcim_api;
+#[cfg(not(docsrs))]
 pub mod extras_api;
+#[cfg(not(docsrs))]
 pub mod ipam_api;
+#[cfg(not(docsrs))]
 pub mod schema_api;
+#[cfg(not(docsrs))]
 pub mod status_api;
+#[cfg(not(docsrs))]
 pub mod tenancy_api;
+#[cfg(not(docsrs))]
 pub mod users_api;
+#[cfg(not(docsrs))]
 pub mod virtualization_api;
+#[cfg(not(docsrs))]
 pub mod vpn_api;
+#[cfg(not(docsrs))]
 pub mod wireless_api;
 
 pub mod configuration;

--- a/crates/netbox-openapi/src/lib.rs
+++ b/crates/netbox-openapi/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
+#![allow(unexpected_cfgs)]
 #[macro_use]
 extern crate serde_derive;
 

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -153,6 +153,7 @@ attrs = "\n".join(
         "#![allow(non_snake_case)]",
         "#![allow(non_camel_case_types)]",
         "#![allow(non_upper_case_globals)]",
+        "#![allow(unexpected_cfgs)]",
         "",
     ]
 )
@@ -161,6 +162,23 @@ if attrs not in content:
     content = attrs + content
     with open(path, "w", encoding="utf-8") as handle:
         handle.write(content)
+PY
+
+echo "Gating per-tag API modules behind cfg(not(docsrs))..."
+python3 - <<'PY' "${HOST_OUTPUT_DIR}/src/apis/mod.rs"
+import re
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as handle:
+    content = handle.read()
+
+pattern = re.compile(r"^pub mod ([a-z_]+_api);$", re.MULTILINE)
+replacement = r"#[cfg(not(docsrs))]\npub mod \1;"
+content = pattern.sub(replacement, content)
+
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(content)
 PY
 
 echo "Normalizing generated Cargo.toml dependencies..."


### PR DESCRIPTION
Actually fixes the docs.rs OOM that 0.5.1 and 0.5.2 didn't.

## What we learned

Both earlier attempts assumed the dominant memory cost was debuginfo (set `debug = 0` for netbox-openapi). Benchmarking with the actual docs.rs constraints (`docker run -m 6442450944`) showed:

| Test | Peak RSS | Result |
|---|---|---|
| `cargo check -j 1` on netbox-openapi, 16 GiB cap | **6.58 GiB** | success in 2:28 |
| same, at docs.rs's 6 GiB cap | clipped at 6.02 GiB | OOM (SIGKILL) at 2:15 |

Type-checking and macro-expanding ~420k lines of generated, derive-heavy code is what costs memory — debuginfo was a small fraction. The 15+ min docs.rs build durations were the kernel thrashing the page cache before the cgroup OOM-killer eventually fired.

## What this PR does

Inspection of how `netbox` actually uses `netbox-openapi` revealed it only depends on `apis::configuration` (`Configuration`, `ApiKey`) and re-exports `apis` and `models`. None of the per-tag `*_api` modules are called by netbox's client — only re-exported for users who want them.

So this gates the per-tag modules behind `#[cfg(not(docsrs))]`:

- `crates/netbox-openapi/src/apis/mod.rs`: `#[cfg(not(docsrs))]` on each of the 13 `pub mod *_api;` declarations. `pub mod configuration;` left unconditional.
- `crates/netbox-openapi/build.rs` (new, 6 lines): translates docs.rs's `DOCS_RS=1` env into `cfg(docsrs)` via `cargo:rustc-cfg=docsrs`. Standard idiom.
- `crates/netbox-openapi/src/lib.rs`: `#![allow(unexpected_cfgs)]`.
- `scripts/generate.sh`: a python post-process that injects the gates after openapi-generator runs, so subsequent regenerations keep them.

## Verification

Reproduced docs.rs's exact docker constraints (`-m 6442450944`, no swap, `rustlang/rust:nightly`, `DOCS_RS=1`):

```
=== cargo check WITH DOCS_RS=1 at 6 GiB limit ===
Elapsed (wall clock) time: 0:46.63
Maximum resident set size (kbytes): 4171032   # 3.98 GiB
Exit status: 0
```

3.98 GiB peak, ~2 GiB headroom under the docs.rs limit, 46-second compile.

## What changes for users

| | crates.io users | docs.rs (netbox-openapi page) | docs.rs (netbox page) |
|---|---|---|---|
| `models::*` | ✓ | ✓ documented | re-exported via netbox |
| `apis::configuration` | ✓ | ✓ documented | used internally |
| `apis::dcim_api` etc. (13 modules) | ✓ | **gated, not documented** | not called by netbox |
| `netbox::Client`, idiomatic API | ✓ | n/a (different crate) | ✓ documented |

No source changes in `crates/netbox` because netbox never calls the gated functions.