### PR TITLE
ci: drop the 'big' runner across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - run: cargo llvm-cov --workspace --all-features --ignore-filename-regex 'crates/netbox-openapi' --fail-under-lines 75 --lcov --output-path lcov.info
+      - run: cargo llvm-cov --workspace --exclude netbox-openapi --all-features --fail-under-lines 75 --lcov --output-path lcov.info
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     env:
       RUSTFLAGS: "-C debuginfo=0"
       CARGO_TARGET_DIR: target/ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
   coverage:
     name: coverage
-    runs-on: big
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       RUSTFLAGS: "-C debuginfo=0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     env:
       RUSTFLAGS: "-C debuginfo=0"
       CARGO_TARGET_DIR: target/ci

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   smoke-and-golden:
-    runs-on: big
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
       NETBOX_URL: http://localhost:8000

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: big
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: write


### PR DESCRIPTION
Moves every `big`-runner job to the free `ubuntu-latest` (4-core / 16 GB), eliminating `big` for this repo.

## Changes
- **integration** (`smoke-and-golden`) → `ubuntu-latest`
- **release** (`publish`) → `ubuntu-latest`
- **coverage** → `ubuntu-latest`, and `--ignore-filename-regex 'crates/netbox-openapi'` → `--exclude netbox-openapi`

## Why the coverage change was needed
`--ignore-filename-regex` only drops the generated crate from the *report* — it was still compiled **and** coverage-instrumented. Instrumenting 400k generated lines pushed the cold build past the 15-min regular-runner wall (it was SIGTERM'd mid-compile of the `netbox` crate). `--exclude` removes the package from the coverage build set entirely, with the same report result.

## Verification
- integration + release + fmt/clippy/test/doc/deny: green on `ubuntu-latest`
- coverage: **2m45s** on `ubuntu-latest` (vs ~3.5 min on `big`) — [run 26959124439](https://github.com/cyberwitchery/netbox.rs/actions/runs/26959124439)

Net: `big` usage in this repo goes from 3 jobs to 0.